### PR TITLE
fix(ci): install Bun on the deploy runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,10 +32,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
-      # - uses: pnpm/action-setup@v3 # Uncomment this block if you're using pnpm
-      #   with:
-      #     version: 9 # Not needed if you've set "packageManager" in package.json
-      # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
+      # docs:build shells out to `bun scripts/generate-llms.ts`, so the Bun
+      # runtime must exist on the runner even though deps install via npm.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
**asena.sh is currently not deploying.** The run for `Merge pull request #15` failed after 16s:

```
> docs:build
> bun run docs:llms && vitepress build

sh: 1: bun: not found
##[error]Process completed with exit code 127.
```

## Cause

`deploy.yml` runs on a Node-only runner — the `oven-sh/setup-bun` line is still commented out from the VitePress template. That was fine until `docs:build` became `bun run docs:llms && vitepress build` (when llms.txt generation was added). Every deploy since then has failed on the missing `bun` binary.

`npm ci` itself is fine — the failed run got past install and died on the build step.

## Fix

Add `oven-sh/setup-bun@v2` before the Node setup. Dependency installation stays on `npm ci`, since `package-lock.json` is committed and already working; this change only puts the Bun runtime on the runner so `scripts/generate-llms.ts` can execute.

I kept it to the one missing step rather than converting the workflow to `bun install`, since master is currently broken and a minimal change is easier to verify.

## Verification

`scripts/generate-llms.ts` only uses `node:fs`, `node:path` and `process.exit` — no Bun-specific APIs — so the Bun runtime is all that was missing. Locally, the npm-driven path (`npm run docs:build`, the exact command CI runs) completes: `llms.txt 42 pages across 7 sections`, `build complete`.