### PR TITLE
docs: correct validation and error-handling, document entry-file components

### DIFF
--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -419,7 +419,7 @@ carry - `z.treeifyError(error.cause)`, for instance. Note that Zod 4 removed
 
 ::: warning Only when a handler exists
 If your application defines no `onError`, the adapter answers validation failures itself
-with its default 400 envelope. See [Validation](/concepts/validation#validation-error-responses).
+with its default 400 envelope. See [Validation](/docs/concepts/validation#validation-error-responses).
 :::
 
 ### Custom Validation Error Response

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -19281,7 +19281,7 @@ carry - `z.treeifyError(error.cause)`, for instance. Note that Zod 4 removed
 
 ::: warning Only when a handler exists
 If your application defines no `onError`, the adapter answers validation failures itself
-with its default 400 envelope. See [Validation](/concepts/validation#validation-error-responses).
+with its default 400 envelope. See [Validation](/docs/concepts/validation#validation-error-responses).
 :::
 
 ### Custom Validation Error Response


### PR DESCRIPTION
Corrects the validation and error-handling pages, which described behaviour that does not occur and an API that does not exist, and documents that components may be declared in the entry file.

## Validation page

- **Adapter support** — the page claimed validation is Ergenecore-only. The Hono adapter ships it too, and the page already showed a Hono tab.
- **Error body shape** — documented as an array of `{ path, message }`. Both adapters emit Zod's flattened error, an object, and Hono adds an undocumented `target` field.
- **Hook signature** — described as receiving "the validated and parsed data" and returning "transformed data". It receives Zod's `SafeParseResult`, so `result.email` is `undefined`; the data lives at `result.data`, and only when `result.success`. The return value is a `Response` override, not a transform — the old Data Transformation example returned a plain object, which is silently ignored.
- **When the hook runs** — Ergenecore runs it only on failure, Hono on every attempt. The "runs after validation succeeds" framing was inverted for Ergenecore. Documented rather than aligned, since aligning would break existing hooks.

## Error-handling page

- Told users to customise validation errors in the global handler, which was not reachable.
- Its example used `error.errors`, removed in Zod 4 in favour of `issues`.
- Both pages now describe the `ValidationError` contract and `isValidationError()`, including the ordering requirement: check it before a generic `HTTPException` branch, or that branch swallows it.

## Entry-file components

Get Started and CLI configuration now state that components may be declared in the entry file, and that they must sit above the bootstrap call to be registered.

## Build fix

`fix(guides): correct validation link path in error-handling` — a `/concepts/validation` link was missing the `/docs` base prefix, which failed the VitePress dead-link check in CI. `npm run docs:build` passes locally (42 pages, no dead links).

`llms-full.txt` regenerated.
