### PR TITLE
docs(concepts): @Strategy cardinality + surface llms-full.txt in nav

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -52,6 +52,7 @@ export default defineConfig({
             {text: "Showcase", link: "/docs/showcase"},
             {text: "Roadmap", link: "/docs/roadmap"},
             {text: "LLMS.txt", link: "/llms.txt"},
+            {text: "LLMS-full.txt", link: "/llms-full.txt"},
         ],
 
         sidebar: [
@@ -61,6 +62,7 @@ export default defineConfig({
             {text: "Showcase", link: "/docs/showcase"},
             {text: "Roadmap", link: "/docs/roadmap"},
             {text: "📄 LLMS.txt", link: "/llms.txt"},
+            {text: "📄 LLMS-full.txt", link: "/llms-full.txt"},
             {
                 text: "Concepts",
                 items: [

--- a/docs/concepts/dependency-injection.md
+++ b/docs/concepts/dependency-injection.md
@@ -288,6 +288,53 @@ export class PaymentService {
 }
 ```
 
+### How many implementations?
+
+A `@Strategy` field is **always an array**, whatever the number of implementations:
+
+| `@Implements('Key')` components | injected value |
+|:--------------------------------|:---------------|
+| 0 | `[]` |
+| 1 | `[implementation]` |
+| 2+ | every implementation |
+
+Zero is a normal state, not a misconfiguration. `@Strategy` is the consumer side of a plugin
+point, and a plugin point with no plugins is how one starts — you write the consumer first and
+the implementations arrive per feature:
+
+```typescript
+@Service()
+export class NotificationManager {
+  @Strategy('NotificationService')
+  private notificationServices: NotificationService[]; // [] until the first @Implements exists
+
+  async notifyUser(userId: string, message: string) {
+    // Works from day one - iterates nothing until a channel is added
+    for (const service of this.notificationServices) {
+      await service.send(userId, message);
+    }
+  }
+}
+```
+
+Because an empty key is legitimate, a **mistyped** interface name cannot fail at boot either — it
+would just stay empty forever. To keep that diagnosable, the container logs one line per injection
+site at startup, at `debug` level:
+
+```
+[IocEngine] Strategy key 'NotificationService' has no implementations - NotificationManager.notificationServices will be injected as []
+```
+
+Enable `debug` on your logger when a strategy collection is unexpectedly empty. Keys supplied
+through a test's `overrides` are not reported.
+
+:::warning Upgrading from 0.9.0
+Up to and including `0.9.0`, a strategy key with no implementations **aborted the boot** with
+`<key> is not registered`, and a key with exactly one implementation injected a **bare instance
+instead of an array** — so `.length`, `for...of` and `.map()` all failed on it at runtime. If you
+worked around either of those, the workaround can go.
+:::
+
 ## Lifecycle Hooks with @PostConstruct
 
 The `@PostConstruct` decorator marks a method to be called **after** all dependencies have been injected and the component is fully constructed.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -3466,6 +3466,53 @@ export class PaymentService {
 }
 ```
 
+### How many implementations?
+
+A `@Strategy` field is **always an array**, whatever the number of implementations:
+
+| `@Implements('Key')` components | injected value |
+|:--------------------------------|:---------------|
+| 0 | `[]` |
+| 1 | `[implementation]` |
+| 2+ | every implementation |
+
+Zero is a normal state, not a misconfiguration. `@Strategy` is the consumer side of a plugin
+point, and a plugin point with no plugins is how one starts — you write the consumer first and
+the implementations arrive per feature:
+
+```typescript
+@Service()
+export class NotificationManager {
+  @Strategy('NotificationService')
+  private notificationServices: NotificationService[]; // [] until the first @Implements exists
+
+  async notifyUser(userId: string, message: string) {
+    // Works from day one - iterates nothing until a channel is added
+    for (const service of this.notificationServices) {
+      await service.send(userId, message);
+    }
+  }
+}
+```
+
+Because an empty key is legitimate, a **mistyped** interface name cannot fail at boot either — it
+would just stay empty forever. To keep that diagnosable, the container logs one line per injection
+site at startup, at `debug` level:
+
+```
+[IocEngine] Strategy key 'NotificationService' has no implementations - NotificationManager.notificationServices will be injected as []
+```
+
+Enable `debug` on your logger when a strategy collection is unexpectedly empty. Keys supplied
+through a test's `overrides` are not reported.
+
+:::warning Upgrading from 0.9.0
+Up to and including `0.9.0`, a strategy key with no implementations **aborted the boot** with
+`<key> is not registered`, and a key with exactly one implementation injected a **bare instance
+instead of an array** — so `.length`, `for...of` and `.map()` all failed on it at runtime. If you
+worked around either of those, the workaround can go.
+:::
+
 ## Lifecycle Hooks with @PostConstruct
 
 The `@PostConstruct` decorator marks a method to be called **after** all dependencies have been injected and the component is fully constructed.


### PR DESCRIPTION
## Ready to merge

`@asenajs/asena@0.9.1` is on npm (`npm view @asenajs/asena version` → `0.9.1`), merged as [AsenaJs/Asena#61](https://github.com/AsenaJs/Asena/pull/61) and tagged `v0.9.1`. The publish gate this PR originally waited on is cleared.

## 1. `@Strategy` cardinality — `concepts/dependency-injection.md`

Documents the behaviour 0.9.1 fixes. Until now every documented `@Strategy` example used exactly two implementations — the only cardinality that worked — so the singular and empty cases were in nobody's mental model, the author's included. That is one of the five reasons the bug survived.

Adds one section, **How many implementations?**:

- a table stating the field is always an array — `[]` / `[implementation]` / all of them
- why zero is the ordinary starting state of a plugin point, not a misconfiguration, continuing the page's existing `NotificationManager` / `NotificationService` example rather than introducing a new cast
- the new `debug` diagnostic, verbatim as `IocEngine` emits it, and the note that `overrides` keys are not reported
- a `:::warning Upgrading from 0.9.0` block: a key with no implementations aborted the boot, and a key with one injected a bare instance whose `.length` / `for...of` / `.map()` failed at runtime

### Verified against source, not the README

Per §4C, checked against `Asena/lib/ioc/`:

- the table matches `Container.resolveStrategy` (`Container.ts:159`) at all three shapes of `_services[key]`
- the log line is copied from `IocEngine.reportEmptyStrategyKeys` character for character
- "at `debug` level" is exact: if the logger has no `debug` method — it is optional on `ServerLogger` — the line is skipped rather than falling back to `console`, which is why the page says to enable `debug` on your logger rather than to look for the line unconditionally

## 2. `llms-full.txt` is now reachable — `.vitepress/config.mts`

`llms.txt` had a nav and sidebar entry; `llms-full.txt` had neither, so nothing on the site linked to it and there was no way to discover it existed. Both now appear in both places.

They are not interchangeable, which is why both are listed rather than one replacing the other:

| file | size | what it is |
|---|---|---|
| `llms.txt` | 7 KB, 77 lines | index — links out to the raw `.md` of each page |
| `llms-full.txt` | 644 KB, 22 443 lines | every page inlined, for pasting into a model |

Verified by building: both land at the dist root and both links render in the navbar (`index.html`) and the sidebar (`docs/get-started.html`).

## 3. `public/llms-full.txt` regenerated

`bun run docs:llms`, per the §5 checklist. `llms.txt` is unchanged — no page was added, only content.
