### PR TITLE
docs: correct CORS, validation and WebSocket publish semantics

### DIFF
--- a/docs/adapters/hono.md
+++ b/docs/adapters/hono.md
@@ -904,4 +904,4 @@ export class MyHonoMiddleware extends AsenaMiddlewareService {
 **Next Steps:**
 - Learn about [Context API](/docs/concepts/context)
 - Explore [Middleware patterns](/docs/concepts/middleware)
-- Understand [@Override decorator](/docs/concepts/middleware#override-decorator)
+- Understand [@Override decorator](/docs/adapters/hono#override-decorator)

--- a/docs/concepts/middleware.md
+++ b/docs/concepts/middleware.md
@@ -359,6 +359,34 @@ export class DynamicCors extends CorsMiddleware {
 }
 ```
 
+#### What a disallowed origin gets
+
+A request from an origin the config rejects is **served normally, without the CORS headers**. It is
+not refused with a 403. CORS is a policy the browser enforces on the user's behalf: a response
+carrying no `Access-Control-Allow-Origin` is one the browser refuses to expose to the calling page,
+which is the denial the spec describes.
+
+The practical consequence is that the middleware is safe to register unconditionally. Non-browser
+callers that happen to send an `Origin` header — server-to-server clients, proxies, webviews — are
+unaffected, and an environment where CORS is already terminated at the ingress needs no conditional
+registration to avoid rejecting forwarded requests.
+
+::: warning Changed in hono-adapter 3.1 / ergenecore 3.1
+Earlier versions answered `403 CORS: Origin not allowed`. If you relied on that as an access
+control, it was never one — put the check in a middleware or guard of your own.
+:::
+
+#### `Vary: Origin`
+
+With any `origin` config other than the literal `'*'`, the response depends on the request's
+`Origin` — the allowed value is reflected back for arrays and functions, and the CORS headers are
+present or absent depending on the caller. The middleware therefore sets `Vary: Origin` on both the
+actual response and the preflight `204`, so a CDN or shared proxy keys its cache on that header.
+
+Without it, a cache in front of the API can serve a response carrying one origin's
+`Access-Control-Allow-Origin` to a request from a different origin. With `origin: '*'` the answer is
+the same for everyone, so no `Vary` is set and cache hit rate is unaffected.
+
 ### Rate Limiter Middleware
 
 ```typescript

--- a/docs/concepts/validation.md
+++ b/docs/concepts/validation.md
@@ -77,7 +77,7 @@ export class UserController {
   @Post({ path: '/', validator: CreateUserValidator })
   async create(context: Context) {
     const body = await context.getBody();
-    // body is guaranteed to be valid!
+    // body is the schema's parsed output, not the raw payload
 
     return context.send({ created: true, user: body }, 201);
   }
@@ -86,6 +86,47 @@ export class UserController {
 
 ::: tip Validation Happens Automatically
 The validator runs **before** your route handler. If validation fails, the handler is never called.
+:::
+
+## What `getBody()` returns
+
+When a route declares a `json` validator, `context.getBody()` returns the **schema's output** - the
+value Zod produced, not the JSON the client sent. That means unknown keys are gone, `default()`s are
+filled in, and `coerce` has been applied:
+
+```typescript
+json() {
+  return z.object({ voteLock: z.boolean() });
+}
+```
+
+```json
+{ "voteLock": true, "ownerId": "<attacker-id>", "password": "plaintext" }
+```
+
+```typescript
+await context.getBody(); // { voteLock: true }
+```
+
+This matters because `z.object()` **ignores** unknown keys rather than rejecting them. Before this
+behaviour existed, `getBody()` re-read the raw body and the two extra keys arrived at the handler
+intact, so the common shape
+
+```typescript
+await this.repository.updateById(id, await context.getBody());
+```
+
+was a mass-assignment sink on every validated route - with a schema sitting right next to it that
+looked like it prevented exactly that.
+
+::: warning Body only
+Only the body is swapped for its validated form. `query`, `param` and `header` schemas still run,
+and still reject bad input, but `getQuery()`, `getParam()` and `headers` return the raw request
+values - a `z.coerce.number()` on a query parameter validates, then hands you the string. Convert
+explicitly in the handler for those targets.
+
+Requires hono-adapter 3.1+ / ergenecore 3.1+. On earlier versions `getBody()` returns the raw body
+on every route, whatever the schema says.
 :::
 
 ## ValidationService API

--- a/docs/concepts/websocket.md
+++ b/docs/concepts/websocket.md
@@ -510,19 +510,19 @@ export class NotificationService {
 
   async sendSystemMessage(room: string, message: string) {
     // Broadcast from outside the WebSocket service
-    this.chatSocket.to(room, JSON.stringify({
+    this.chatSocket.to(room, {
       type: 'system_message',
       message,
       timestamp: new Date().toISOString()
-    }));
+    });
   }
 
   async notifyAllUsers(message: string) {
     // Broadcast to all connected clients
-    this.chatSocket.in(JSON.stringify({
+    this.chatSocket.in({
       type: 'notification',
       message
-    }));
+    });
   }
 }
 ```
@@ -603,20 +603,20 @@ export class UserService {
     // ... update user in database
 
     // Notify the user via WebSocket
-    this.notificationSocket.to(`user:${userId}`, JSON.stringify({
+    this.notificationSocket.to(`user:${userId}`, {
       type: 'profile_updated',
       message: 'Your profile has been updated',
       timestamp: new Date().toISOString()
-    }));
+    });
   }
 
   async sendGlobalAnnouncement(message: string): Promise<void> {
     // Broadcast to all users subscribed to announcements
-    this.notificationSocket.to('announcements', JSON.stringify({
+    this.notificationSocket.to('announcements', {
       type: 'announcement',
       message,
       timestamp: new Date().toISOString()
-    }));
+    });
   }
 }
 ```
@@ -641,11 +641,11 @@ export class AdminController {
     const { message } = await context.getBody<{ message: string }>();
 
     // Broadcast to all connected clients
-    this.notificationSocket.to('announcements', JSON.stringify({
+    this.notificationSocket.to('announcements', {
       type: 'announcement',
       message,
       timestamp: new Date().toISOString()
-    }));
+    });
 
     return context.send({ success: true });
   }
@@ -830,23 +830,26 @@ for (const socket of this.sockets.values()) {
 ### 3. Let Asena Handle Cleanup
 
 ```typescript
-// ✅ Good: Asena handles cleanup automatically
+// ✅ Good: leave cleanup alone and use onClose for your own state
 protected async onClose(ws: Socket) {
-  // Just unsubscribe from rooms
-  ws.unsubscribe('room-1');
+  await this.presenceService.markOffline(ws.data.id);
 
   // Asena automatically:
-  // - Removes socket from this.sockets
-  // - Cleans up room references
+  // - Removes the socket from this.sockets
+  // - Unsubscribes it from the topics it manages
   // - Handles connection termination
 }
 
 // ❌ Bad: Manual cleanup (unnecessary and error-prone)
 protected async onClose(ws: Socket) {
-  this.sockets.delete(ws.id);           // Asena does this!
-  this.rooms.forEach(r => r.delete(ws)); // Asena does this too!
+  this.sockets.delete(ws.id);  // Asena does this!
+  ws.unsubscribe('room-1');    // Bun drops every subscription when the socket closes!
 }
 ```
+
+Room subscriptions need no cleanup at all: they live in Bun's pub/sub topics and disappear with
+the connection. There is no `this.rooms` map to sweep — see
+[Built-in Room Management](#built-in-room-management) above.
 
 ## Breaking Circular Dependencies with Ulak
 

--- a/docs/concepts/websocket.md
+++ b/docs/concepts/websocket.md
@@ -177,6 +177,27 @@ export class ChatSocket extends AsenaWebSocketService<ChatData> {
 
 Use `ws.publish()` to broadcast messages to all subscribers of a room:
 
+::: warning `ws.publish()` excludes the sender
+`ws.publish()`, `ws.publishText()` and `ws.publishBinary()` deliver to every subscriber of the
+topic **except the socket that called them**. If the sender should see the message too, send it
+explicitly:
+
+```typescript
+const payload = JSON.stringify({ type: 'message', text });
+
+ws.publish(room, payload);
+ws.send(payload); // the sender, who publish() left out
+```
+
+The service-level `this.to()` / `this.in()` are the opposite: they reach every subscriber,
+sender included. Pick by whether the sender is meant to be in the audience.
+
+This rule does **not** change when you configure a `transport()`. Before `@asenajs/asena` 0.10.1
+it did - a transport routed `ws.publish()` through `server.publish()`, which cannot exclude
+anything, so adding one for multi-pod delivery silently started echoing every publish back to its
+sender.
+:::
+
 ```typescript
 protected async onMessage(ws: Socket<ChatData>, message: string): Promise<void> {
   const room = ws.data?.values.room || 'general';
@@ -715,19 +736,48 @@ public transport() {
 
 Each server instance gets a unique pod ID. When a WebSocket message is published:
 
-1. The message is delivered locally via `server.publish()`
+1. The message is delivered locally — via `server.publish()` for `this.to()`, via the socket's own
+   `ws.publish()` for `socket.publish()` (which is what keeps the sender excluded there)
 2. The message is sent to Redis pub/sub with the originating pod ID
 3. Other pods receive the message and deliver it to their local sockets
 4. Messages from the same pod are deduplicated automatically
 
 ::: tip No Code Changes
 Your WebSocket services, Ulak messaging, and room management work exactly the same with `RedisTransport`. The transport layer is transparent — just configure it in `@Config` and multi-pod support is enabled.
+
+A transport changes **where** a message can reach, never **who** receives it locally. Adding one
+does not start or stop delivering a socket's own publish back to it.
 :::
 
 ::: info Custom Transports
-The `WebSocketTransport` interface (from `@asenajs/asena`) defines a required `publish()` plus optional `init()` and `destroy()` hooks. You can implement custom transports for other message brokers like NATS or RabbitMQ.
+The `WebSocketTransport` interface (from `@asenajs/asena`) defines a required `publish()` plus optional `publishRemote()`, `init()` and `destroy()` hooks. You can implement custom transports for other message brokers like NATS or RabbitMQ.
+
+`publish()` is responsible for **both** local and remote delivery — `server.publish()` plus the broker — and is what the service-level `this.to()` uses.
+
+`publishRemote()` is the wire half alone: the broker publish with **no** `server.publish()`. `socket.publish()` calls it after having done local delivery itself through Bun's socket-level `ws.publish()`, the only primitive that can leave the publishing socket out. A transport that does local delivery again here would both duplicate the message locally and echo it back to the sender.
+
+```typescript
+export class MyTransport implements WebSocketTransport {
+  public publish(topic: string, data: string | ArrayBuffer | ArrayBufferView): void {
+    this.server.publish(topic, data);  // local
+    this.publishRemote(topic, data);   // remote
+  }
+
+  public publishRemote(topic: string, data: string | ArrayBuffer | ArrayBufferView): void {
+    this.broker.publish(topic, envelope(data, this.podId)); // remote only
+  }
+}
+```
 
 `init(server)` is called during startup, before any connection is accepted. `destroy()` is called from `server.stop()`, when the adapter shuts the WebSocket layer down — under a 5s ceiling, with failures logged and stepped over so one unreachable broker cannot hold the shutdown open.
+:::
+
+::: warning Implement `publishRemote()` in custom transports
+It is optional only for backwards compatibility. A transport without it keeps the pre-0.10.1 behaviour — `socket.publish()` falls back to `publish()`, so the message is delivered to the sender as well — and the adapter warns once at startup. The fallback is removed in the next major version.
+
+It is optional rather than required because the alternative reading of a missing method, "do not forward anywhere", would drop every cross-pod message in silence. A wrong-but-delivered message beats a lost one.
+
+The same warning appears if the adapter is 3.1+ while `@asenajs/asena` is still `0.10.0` — the peer range `^0.10.0` permits that pairing, and on it `BunLocalTransport` has no `publishRemote()` either. Upgrading core to 0.10.1 clears it.
 :::
 
 ::: warning `destroy()` was never called before 0.10.0

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5012,6 +5012,34 @@ export class DynamicCors extends CorsMiddleware {
 }
 ```
 
+#### What a disallowed origin gets
+
+A request from an origin the config rejects is **served normally, without the CORS headers**. It is
+not refused with a 403. CORS is a policy the browser enforces on the user's behalf: a response
+carrying no `Access-Control-Allow-Origin` is one the browser refuses to expose to the calling page,
+which is the denial the spec describes.
+
+The practical consequence is that the middleware is safe to register unconditionally. Non-browser
+callers that happen to send an `Origin` header — server-to-server clients, proxies, webviews — are
+unaffected, and an environment where CORS is already terminated at the ingress needs no conditional
+registration to avoid rejecting forwarded requests.
+
+::: warning Changed in hono-adapter 3.1 / ergenecore 3.1
+Earlier versions answered `403 CORS: Origin not allowed`. If you relied on that as an access
+control, it was never one — put the check in a middleware or guard of your own.
+:::
+
+#### `Vary: Origin`
+
+With any `origin` config other than the literal `'*'`, the response depends on the request's
+`Origin` — the allowed value is reflected back for arrays and functions, and the CORS headers are
+present or absent depending on the caller. The middleware therefore sets `Vary: Origin` on both the
+actual response and the preflight `204`, so a CDN or shared proxy keys its cache on that header.
+
+Without it, a cache in front of the API can serve a response carrying one origin's
+`Access-Control-Allow-Origin` to a request from a different origin. With `origin: '*'` the answer is
+the same for everyone, so no `Vary` is set and cache hit rate is unaffected.
+
 ### Rate Limiter Middleware
 
 ```typescript
@@ -6474,7 +6502,7 @@ export class UserController {
   @Post({ path: '/', validator: CreateUserValidator })
   async create(context: Context) {
     const body = await context.getBody();
-    // body is guaranteed to be valid!
+    // body is the schema's parsed output, not the raw payload
 
     return context.send({ created: true, user: body }, 201);
   }
@@ -6483,6 +6511,47 @@ export class UserController {
 
 ::: tip Validation Happens Automatically
 The validator runs **before** your route handler. If validation fails, the handler is never called.
+:::
+
+## What `getBody()` returns
+
+When a route declares a `json` validator, `context.getBody()` returns the **schema's output** - the
+value Zod produced, not the JSON the client sent. That means unknown keys are gone, `default()`s are
+filled in, and `coerce` has been applied:
+
+```typescript
+json() {
+  return z.object({ voteLock: z.boolean() });
+}
+```
+
+```json
+{ "voteLock": true, "ownerId": "<attacker-id>", "password": "plaintext" }
+```
+
+```typescript
+await context.getBody(); // { voteLock: true }
+```
+
+This matters because `z.object()` **ignores** unknown keys rather than rejecting them. Before this
+behaviour existed, `getBody()` re-read the raw body and the two extra keys arrived at the handler
+intact, so the common shape
+
+```typescript
+await this.repository.updateById(id, await context.getBody());
+```
+
+was a mass-assignment sink on every validated route - with a schema sitting right next to it that
+looked like it prevented exactly that.
+
+::: warning Body only
+Only the body is swapped for its validated form. `query`, `param` and `header` schemas still run,
+and still reject bad input, but `getQuery()`, `getParam()` and `headers` return the raw request
+values - a `z.coerce.number()` on a query parameter validates, then hands you the string. Convert
+explicitly in the handler for those targets.
+
+Requires hono-adapter 3.1+ / ergenecore 3.1+. On earlier versions `getBody()` returns the raw body
+on every route, whatever the schema says.
 :::
 
 ## ValidationService API
@@ -8031,6 +8100,27 @@ export class ChatSocket extends AsenaWebSocketService<ChatData> {
 
 Use `ws.publish()` to broadcast messages to all subscribers of a room:
 
+::: warning `ws.publish()` excludes the sender
+`ws.publish()`, `ws.publishText()` and `ws.publishBinary()` deliver to every subscriber of the
+topic **except the socket that called them**. If the sender should see the message too, send it
+explicitly:
+
+```typescript
+const payload = JSON.stringify({ type: 'message', text });
+
+ws.publish(room, payload);
+ws.send(payload); // the sender, who publish() left out
+```
+
+The service-level `this.to()` / `this.in()` are the opposite: they reach every subscriber,
+sender included. Pick by whether the sender is meant to be in the audience.
+
+This rule does **not** change when you configure a `transport()`. Before `@asenajs/asena` 0.10.1
+it did - a transport routed `ws.publish()` through `server.publish()`, which cannot exclude
+anything, so adding one for multi-pod delivery silently started echoing every publish back to its
+sender.
+:::
+
 ```typescript
 protected async onMessage(ws: Socket<ChatData>, message: string): Promise<void> {
   const room = ws.data?.values.room || 'general';
@@ -8569,19 +8659,48 @@ public transport() {
 
 Each server instance gets a unique pod ID. When a WebSocket message is published:
 
-1. The message is delivered locally via `server.publish()`
+1. The message is delivered locally — via `server.publish()` for `this.to()`, via the socket's own
+   `ws.publish()` for `socket.publish()` (which is what keeps the sender excluded there)
 2. The message is sent to Redis pub/sub with the originating pod ID
 3. Other pods receive the message and deliver it to their local sockets
 4. Messages from the same pod are deduplicated automatically
 
 ::: tip No Code Changes
 Your WebSocket services, Ulak messaging, and room management work exactly the same with `RedisTransport`. The transport layer is transparent — just configure it in `@Config` and multi-pod support is enabled.
+
+A transport changes **where** a message can reach, never **who** receives it locally. Adding one
+does not start or stop delivering a socket's own publish back to it.
 :::
 
 ::: info Custom Transports
-The `WebSocketTransport` interface (from `@asenajs/asena`) defines a required `publish()` plus optional `init()` and `destroy()` hooks. You can implement custom transports for other message brokers like NATS or RabbitMQ.
+The `WebSocketTransport` interface (from `@asenajs/asena`) defines a required `publish()` plus optional `publishRemote()`, `init()` and `destroy()` hooks. You can implement custom transports for other message brokers like NATS or RabbitMQ.
+
+`publish()` is responsible for **both** local and remote delivery — `server.publish()` plus the broker — and is what the service-level `this.to()` uses.
+
+`publishRemote()` is the wire half alone: the broker publish with **no** `server.publish()`. `socket.publish()` calls it after having done local delivery itself through Bun's socket-level `ws.publish()`, the only primitive that can leave the publishing socket out. A transport that does local delivery again here would both duplicate the message locally and echo it back to the sender.
+
+```typescript
+export class MyTransport implements WebSocketTransport {
+  public publish(topic: string, data: string | ArrayBuffer | ArrayBufferView): void {
+    this.server.publish(topic, data);  // local
+    this.publishRemote(topic, data);   // remote
+  }
+
+  public publishRemote(topic: string, data: string | ArrayBuffer | ArrayBufferView): void {
+    this.broker.publish(topic, envelope(data, this.podId)); // remote only
+  }
+}
+```
 
 `init(server)` is called during startup, before any connection is accepted. `destroy()` is called from `server.stop()`, when the adapter shuts the WebSocket layer down — under a 5s ceiling, with failures logged and stepped over so one unreachable broker cannot hold the shutdown open.
+:::
+
+::: warning Implement `publishRemote()` in custom transports
+It is optional only for backwards compatibility. A transport without it keeps the pre-0.10.1 behaviour — `socket.publish()` falls back to `publish()`, so the message is delivered to the sender as well — and the adapter warns once at startup. The fallback is removed in the next major version.
+
+It is optional rather than required because the alternative reading of a missing method, "do not forward anywhere", would drop every cross-pod message in silence. A wrong-but-delivered message beats a lost one.
+
+The same warning appears if the adapter is 3.1+ while `@asenajs/asena` is still `0.10.0` — the peer range `^0.10.0` permits that pairing, and on it `BunLocalTransport` has no `publishRemote()` either. Upgrading core to 0.10.1 clears it.
 :::
 
 ::: warning `destroy()` was never called before 0.10.0

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8433,19 +8433,19 @@ export class NotificationService {
 
   async sendSystemMessage(room: string, message: string) {
     // Broadcast from outside the WebSocket service
-    this.chatSocket.to(room, JSON.stringify({
+    this.chatSocket.to(room, {
       type: 'system_message',
       message,
       timestamp: new Date().toISOString()
-    }));
+    });
   }
 
   async notifyAllUsers(message: string) {
     // Broadcast to all connected clients
-    this.chatSocket.in(JSON.stringify({
+    this.chatSocket.in({
       type: 'notification',
       message
-    }));
+    });
   }
 }
 ```
@@ -8526,20 +8526,20 @@ export class UserService {
     // ... update user in database
 
     // Notify the user via WebSocket
-    this.notificationSocket.to(`user:${userId}`, JSON.stringify({
+    this.notificationSocket.to(`user:${userId}`, {
       type: 'profile_updated',
       message: 'Your profile has been updated',
       timestamp: new Date().toISOString()
-    }));
+    });
   }
 
   async sendGlobalAnnouncement(message: string): Promise<void> {
     // Broadcast to all users subscribed to announcements
-    this.notificationSocket.to('announcements', JSON.stringify({
+    this.notificationSocket.to('announcements', {
       type: 'announcement',
       message,
       timestamp: new Date().toISOString()
-    }));
+    });
   }
 }
 ```
@@ -8564,11 +8564,11 @@ export class AdminController {
     const { message } = await context.getBody<{ message: string }>();
 
     // Broadcast to all connected clients
-    this.notificationSocket.to('announcements', JSON.stringify({
+    this.notificationSocket.to('announcements', {
       type: 'announcement',
       message,
       timestamp: new Date().toISOString()
-    }));
+    });
 
     return context.send({ success: true });
   }
@@ -8753,23 +8753,26 @@ for (const socket of this.sockets.values()) {
 ### 3. Let Asena Handle Cleanup
 
 ```typescript
-// ✅ Good: Asena handles cleanup automatically
+// ✅ Good: leave cleanup alone and use onClose for your own state
 protected async onClose(ws: Socket) {
-  // Just unsubscribe from rooms
-  ws.unsubscribe('room-1');
+  await this.presenceService.markOffline(ws.data.id);
 
   // Asena automatically:
-  // - Removes socket from this.sockets
-  // - Cleans up room references
+  // - Removes the socket from this.sockets
+  // - Unsubscribes it from the topics it manages
   // - Handles connection termination
 }
 
 // ❌ Bad: Manual cleanup (unnecessary and error-prone)
 protected async onClose(ws: Socket) {
-  this.sockets.delete(ws.id);           // Asena does this!
-  this.rooms.forEach(r => r.delete(ws)); // Asena does this too!
+  this.sockets.delete(ws.id);  // Asena does this!
+  ws.unsubscribe('room-1');    // Bun drops every subscription when the socket closes!
 }
 ```
+
+Room subscriptions need no cleanup at all: they live in Bun's pub/sub topics and disappear with
+the connection. There is no `this.rooms` map to sweep — see
+[Built-in Room Management](#built-in-room-management) above.
 
 ## Breaking Circular Dependencies with Ulak
 
@@ -14282,7 +14285,7 @@ export class MyHonoMiddleware extends AsenaMiddlewareService {
 **Next Steps:**
 - Learn about [Context API](/docs/concepts/context)
 - Explore [Middleware patterns](/docs/concepts/middleware)
-- Understand [@Override decorator](/docs/concepts/middleware#override-decorator)
+- Understand [@Override decorator](/docs/adapters/hono#override-decorator)
 
 
 ---

--- a/scripts/generate-llms.ts
+++ b/scripts/generate-llms.ts
@@ -9,7 +9,7 @@
  * Run via `bun run docs:llms` (also runs automatically as part of `bun run docs:build`).
  */
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { join, relative, resolve, sep } from 'node:path';
 
 const ROOT = resolve(import.meta.dir, '..');
 const DOCS_DIR = join(ROOT, 'docs');
@@ -148,7 +148,10 @@ sections.unshift({ title: 'Docs', pages: topLevel });
 const orphans: Page[] = [];
 
 for (const absPath of listDocs(DOCS_DIR)) {
-  const docsPath = relative(DOCS_DIR, absPath);
+  // `seen` and the raw URLs are built from sidebar links, which are always POSIX. On Windows
+  // `relative()` answers with backslashes, so without this every page misses the dedupe and gets
+  // listed a second time under "Other" with a broken URL.
+  const docsPath = relative(DOCS_DIR, absPath).split(sep).join('/');
 
   if (seen.has(docsPath)) {
     continue;


### PR DESCRIPTION
## Problem

Three pages described behaviour the framework did not have. In two cases the documentation is what made the underlying bug dangerous — it told users a guarantee existed, so nobody went looking.

**validation.md** said, next to a `getBody()` call:

```ts
const body = await context.getBody();
// body is guaranteed to be valid!
```

It was not. Both adapters returned the raw request body, so a schema declaring four keys handed the handler whatever the client sent — the mass-assignment problem in [hono-adapter#17](https://github.com/AsenaJs/hono-adapter/pull/17) and [ergenecore#15](https://github.com/AsenaJs/ergenecore/pull/15).

**middleware.md** documented `CorsMiddleware`'s options and nothing about its semantics — not that a disallowed origin was refused with `403`, not that the reflected `Access-Control-Allow-Origin` carried no `Vary`.

**websocket.md** never stated that `ws.publish()` excludes the sender. The word appears nowhere on the page, in either direction, which left the single most surprising thing about the API undocumented — and left users with no way to know that configuring a `transport()` silently changed it.

## Approach

### validation.md

New **"What `getBody()` returns"** section: the schema's output, with unknown keys stripped and defaults and coercions applied, shown with the concrete attacker payload and what the handler actually receives. It records why this matters — `z.object()` *ignores* unknown keys rather than rejecting them — and the deliberate limit, in a warning block: only the body is swapped, so a `z.coerce.number()` on a query parameter validates and then hands you the string.

The `// body is guaranteed to be valid!` comment is replaced with something true.

### middleware.md

Two new subsections under CORS:

- **What a disallowed origin gets** — served normally without CORS headers, not refused. Explains that this is the denial the spec describes and that the practical consequence is the middleware being safe to register unconditionally, with a changed-in note for anyone who relied on the 403.
- **`Vary: Origin`** — why a reflected allowed-origin header without it lets a shared cache serve one origin's response to another, and why `'*'` correctly sets nothing.

### websocket.md

A warning block at the first `ws.publish()` example stating that it excludes the sender, with the `publish()` + `send()` pattern for including them, and the contrast against service-level `this.to()`. It also names the rule the old behaviour broke: **a transport changes where a message can reach, never who receives it locally.**

The multi-pod section gains the `publish()` vs `publishRemote()` contract with a code example, for anyone writing a transport for NATS or RabbitMQ, and a warning explaining why `publishRemote()` is optional in the type but should always be implemented — a missing method read as "forward nowhere" would lose every cross-pod message in silence.

The "How It Works" numbered list is corrected: local delivery is `server.publish()` for `this.to()` but `ws.publish()` for `socket.publish()`, which is what keeps the sender excluded there.

## Notes

`public/llms-full.txt` is regenerated via `bun run docs:llms`. Its diff is exactly 125 added lines, matching the 28 + 43 + 54 added to the three pages — no unrelated content pulled in.

Targets hono-adapter 3.1 / ergenecore 3.1 and `@asenajs/asena` 0.10.1, so this should merge after those.
